### PR TITLE
VZ-11257: change name prefix for k8s resources 

### DIFF
--- a/api/v1alpha1/verrazzanofleet_types.go
+++ b/api/v1alpha1/verrazzanofleet_types.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	// HelmChartFinalizer is the finalizer used by the VerrazzanoFleet controller to cleanup add-on resources when
+	// VerrazzanoFleetFinalizer is the finalizer used by the VerrazzanoFleet controller to cleanup add-on resources when
 	// a VerrazzanoFleet is being deleted.
 	VerrazzanoFleetFinalizer = "verrazzanofleet.addons.cluster.x-k8s.io"
 )

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: caapv-system
+namespace: capi-verrazzano-addon-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: caapv-
+namePrefix: capi-verrazzano-addon-
 
 # Labels to add to all resources and selectors.
 commonLabels:


### PR DESCRIPTION
This pull request changes the name prefix for k8s resources so they are consistent with other capi resources.