### PR TITLE
VZ-11595: Uptake new golang base image go1.20.12 (#16)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.20.10
-GO_CONTAINER_IMAGE ?= ghcr.io/verrazzano/golang:v1.20.10
+GO_VERSION ?= 1.20.12
+GO_CONTAINER_IMAGE ?= ghcr.io/verrazzano/golang:v${GO_VERSION}
 FINAL_IMAGE ?= ghcr.io/oracle/oraclelinux:8-slim
 
 # Use GOPROXY environment variable if set


### PR DESCRIPTION
* VZ-11595: Uptake new golang base image go1.20.12

* VZ-11595: fix syntax